### PR TITLE
feat: add support for metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,24 @@ api = API(
 Methods currently implemented:
 
 
-| Method  | description |
-| ------------- | ------------- |
-| `api.iter_people()`  | Generator iterating over people  |
-| `api.iter_events()`  | Generator iterating over events  |
-| `api.iter_places()`  | Generator iterating over places  |
-| `api.iter_media()`  | Generator iterating over media objects  |
-| `api.get_person(handle)`  | Get a single person by handle  |
-| `api.get_event(handle)`  | Get a single event by handle  |
-| `api.get_place(handle)`  | Get a single place by handle  |
-| `api.get_media(handle)`  | Get a single media object by handle  |
-| `api.update_person(handle, data)`  | Update a single person  |
-| `api.update_event(handle, data)`  | Update a single event  |
-| `api.update_place(handle, data)`  | Update a single place |
-| `api.update_media(handle, data)`  | Update a single media object |
-| `api.create_person(data)`  | Create a new person  |
-| `api.create_event(data)`  | Create a new evebt  |
-| `api.create_place(data)`  | Create a new place  |
+| Method                               | description                             |
+|--------------------------------------|-----------------------------------------|
+| `api.iter_people()`                  | Generator iterating over people         |
+| `api.iter_events()`                  | Generator iterating over events         |
+| `api.iter_places()`                  | Generator iterating over places         |
+| `api.iter_media()`                   | Generator iterating over media objects  |
+| `api.get_person(handle)`             | Get a single person by handle           |
+| `api.get_event(handle)`              | Get a single event by handle            |
+| `api.get_place(handle)`              | Get a single place by handle            |
+| `api.get_media(handle)`              | Get a single media object by handle     |
+| `api.get_metadata(include_surnames)` | Get metadata about the current instance |
+| `api.update_person(handle, data)`    | Update a single person                  |
+| `api.update_event(handle, data)`     | Update a single event                   |
+| `api.update_place(handle, data)`     | Update a single place                   |
+| `api.update_media(handle, data)`     | Update a single media object            |
+| `api.create_person(data)`            | Create a new person                     |
+| `api.create_event(data)`             | Create a new evebt                      |
+| `api.create_place(data)`             | Create a new place                      |
 
 
 In all cases, `data` are dictionaries for JSON objects following the Gramps Web API conventions.

--- a/src/gramps_web_api_client/api.py
+++ b/src/gramps_web_api_client/api.py
@@ -11,6 +11,7 @@ ENDPOINT_PEOPLE = "/people/"
 ENDPOINT_EVENTS = "/events/"
 ENDPOINT_PLACES = "/places/"
 ENDPOINT_MEDIA = "/media/"
+ENDPOINT_METADATA = "/metadata/"
 PAGE_SIZE = 200
 
 
@@ -139,6 +140,10 @@ class API:
     def get_media(self, handle: str):
         """Get a single media object."""
         return self._get_object(ENDPOINT_MEDIA, handle)
+
+    def get_metadata(self, include_surnames: bool = False):
+        """Get a single metadata object."""
+        return self._get_object(f"{ENDPOINT_METADATA}?surnames={include_surnames}", handle)
 
     def iter_people(self, **kwargs):
         """Iterate over people."""


### PR DESCRIPTION
This adds support for the [`/metadata` endpoint](https://gramps-project.github.io/gramps-web-api/#/metadata/getMetadata).

This endpoint allows retrieving statistical data such as component versions, locale, object counts, and more. The `include_surnames` argument is optional, and will include a list of all surnames in the database if `true`.